### PR TITLE
wwwをﾜﾗﾜﾗﾜﾗと発音するようにする

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ export const App = () => {
   const speak = (text: string) => {
     return new Promise((resolve, _reject) => {
       speechSynthesis.cancel()
-      const options = new SpeechSynthesisUtterance(text)
+      const options = new SpeechSynthesisUtterance(text.replace('www', 'わらわらわら'))
       options.lang = 'ja-JP'
       options.onend = options.onerror = () => resolve(speechSynthesis.cancel())
       speechSynthesis.speak(options)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ export const App = () => {
   const speak = (text: string) => {
     return new Promise((resolve, _reject) => {
       speechSynthesis.cancel()
-      const options = new SpeechSynthesisUtterance(text.replace('www', 'わらわらわら'))
+      const options = new SpeechSynthesisUtterance(text.replace(/w/g, 'ﾜﾗ'))
       options.lang = 'ja-JP'
       options.onend = options.onerror = () => resolve(speechSynthesis.cancel())
       speechSynthesis.speak(options)


### PR DESCRIPTION
`www`は「ワールドワイドウェブ」と発音されてしまうため、ﾜﾗﾜﾗﾜﾗと発音するように修正